### PR TITLE
Adding 068_shortest_path_Haskell.hs 030_quicksort_R.R 066_shortest_path_CSharp.cs 019_binary_search_Scheme.scm 012_binary_search_Rust.rs 073_shortest_path_Erlang.erl 009_binary_search_MATLAB.m

### DIFF
--- a/dev_src/009_binary_search_MATLAB.m
+++ b/dev_src/009_binary_search_MATLAB.m
@@ -1,0 +1,151 @@
+
+function binary_search_cli(target, filepath)
+% binary_search_cli — Binary search over a sorted list of integers.
+%
+% USAGE (pick one):
+%   % A) From MATLAB/Octave command line, using a file with one integer per line:
+%   binary_search_cli(11, 'data.txt')
+%
+%   % B) From MATLAB/Octave, passing a numeric vector directly (no file):
+%   binary_search_cli(11, [1 3 4 7 9 11 15])
+%
+%   % C) From system shell (if MATLAB/Octave is on PATH), non-interactive:
+%   %   matlab -batch "binary_search_cli(11, 'data.txt')"
+%   %   octave --quiet --eval "binary_search_cli(11, 'data.txt')"
+%
+% BEHAVIOR:
+%   • Performs classic binary search (O(log N)).
+%   • On success, prints: FOUND <target> at index <i> (1-based)
+%   • On miss, prints:   NOT FOUND <target>. Insertion index <i> (1-based) ...
+%   • If duplicates exist, reports the FIRST occurrence.
+%
+% NOTES:
+%   • Input must be in NON-DECREASING (ascending) order.
+%   • Non-integer values are allowed but will be rounded toward nearest integer
+%     for display; the comparison itself is numeric (double).
+%
+% RETURNS:
+%   This is a CLI-style function and does not return a value. For programmatic
+%   use, see the local function [idx,found,ins] = binary_search(vec, target, firstOccurrence).
+
+  % -------- Parse inputs / load vector --------
+  if nargin < 2
+    error('Usage: binary_search_cli(TARGET, FILEPATH or VECTOR)');
+  end
+
+  vec = [];
+  if isnumeric(filepath)
+    vec = double(filepath(:).');         % row vector
+  elseif ischar(filepath) || isstring(filepath)
+    fp = char(filepath);
+    if ~isfile(fp)
+      error('File not found: %s', fp);
+    end
+    % Robust file read: one number per line (ignores blanks, skips text)
+    vec = read_numeric_column(fp);
+  else
+    error('Second argument must be a filename (char/string) or a numeric vector.');
+  end
+
+  if isempty(vec)
+    error('No numeric data to search.');
+  end
+
+  % -------- Validate monotonicity (ascending) --------
+  if any(diff(vec) < 0)
+    error('Input data is not in ascending order (required for binary search).');
+  end
+
+  tgt = double(target);
+
+  % -------- Perform binary search for FIRST occurrence --------
+  [idx, found, ins] = binary_search(vec, tgt, true);
+
+  % -------- Report --------
+  if found
+    fprintf('FOUND %g at index %d (1-based)\n', tgt, idx);
+  else
+    left  = '-inf';
+    right = '+inf';
+    if ins > 1,      left  = num2str(vec(ins-1)); end
+    if ins <= numel(vec), right = num2str(vec(ins));   end
+    fprintf('NOT FOUND %g. Insertion index %d (1-based), between %s and %s\n', tgt, ins, left, right);
+  end
+end
+
+
+% === Local, programmatic API ===
+function [idx, found, insertPos] = binary_search(vec, target, firstOccurrence)
+% [idx, found, insertPos] = binary_search(vec, target, firstOccurrence)
+%   vec             : ascending numeric vector
+%   target          : numeric scalar
+%   firstOccurrence : if true, return first index among duplicates
+%
+% RETURNS
+%   idx       : index of first matching element, if found; undefined if not
+%   found     : logical scalar
+%   insertPos : insertion index (1-based) that would keep vec sorted (always set)
+%
+% Complexity: O(log N)
+
+  n  = numel(vec);
+  lo = 1;
+  hi = n;
+  idx = -1;
+
+  while lo <= hi
+    mid = floor((lo + hi) / 2);
+    val = vec(mid);
+    if val == target
+      idx = mid;
+      if firstOccurrence
+        hi = mid - 1;   % shrink left to find first
+      else
+        break;
+      end
+    elseif val < target
+      lo = mid + 1;
+    else
+      hi = mid - 1;
+    end
+  end
+
+  found = (idx ~= -1);
+  if found && firstOccurrence
+    % idx already first by construction
+  elseif ~found
+    % lo is the insertion point (1..n+1)
+    idx = NaN;
+  end
+  insertPos = lo;
+end
+
+
+function vec = read_numeric_column(fp)
+% Read a single numeric column from text file `fp`. Skips blank lines and
+% warns on garbage lines. Returns a row vector of doubles.
+
+  fid = fopen(fp, 'r');
+  if fid == -1, error('Could not open file: %s', fp); end
+  c = onCleanup(@() fclose(fid));
+
+  data = []; dataIdx = 0;
+  lineNo = 0;
+  while true
+    t = fgetl(fid);
+    if ~ischar(t), break; end
+    lineNo = lineNo + 1;
+    s = strtrim(t);
+    if isempty(s), continue; end
+    v = str2double(s);
+    if ~isnan(v)
+      dataIdx = dataIdx + 1;
+      data(dataIdx,1) = v; %#ok<AGROW>
+    else
+      warning('Skipping non-numeric line %d: %s', lineNo, t);
+    end
+  end
+
+  vec = double(data(:).');  % row
+end
+

--- a/dev_src/012_binary_search_Rust.rs
+++ b/dev_src/012_binary_search_Rust.rs
@@ -1,0 +1,180 @@
+// main.rs
+//
+// Binary search over a sorted (ascending) list of numbers, as a tiny CLI.
+// - Usage:
+//     cargo run -- <target> [path/to/file]
+//     # or, without file, read numbers (one per line) from STDIN:
+//     printf "1\n3\n4\n7\n9\n11\n15\n" | cargo run -- 11
+//
+// Behavior
+//   • O(log N) classic binary search on f64 values.
+//   • Returns the FIRST occurrence if duplicates exist (stable-left).
+//   • On hit : prints  FOUND <target> at index <i> (1-based)
+//   • On miss: prints  NOT FOUND <target>. Insertion index <i> (1-based), between <left> and <right>
+//   • Validates non-decreasing order and errors out if violated.
+//
+// Notes
+//   • If you prefer integers, change f64→i64 and parsing accordingly.
+
+use std::env;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+use std::process;
+
+// -----------------------------
+// Core algorithm (library API)
+// -----------------------------
+
+/// Binary search over ascending slice `arr` for `target`.
+/// Returns (idx_1based, found, insert_pos_1based).
+fn binary_search_first(arr: &[f64], target: f64) -> (usize, bool, usize) {
+    let mut lo: isize = 0;
+    let mut hi: isize = arr.len() as isize - 1;
+    let mut found_idx: isize = -1;
+
+    while lo <= hi {
+        let mid = lo + (hi - lo) / 2;
+        let v = arr[mid as usize];
+        if v == target {
+            found_idx = mid;
+            // keep searching left half to get FIRST occurrence
+            hi = mid - 1;
+        } else if v < target {
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    if found_idx >= 0 {
+        (found_idx as usize + 1, true, (lo as usize) + 1)
+    } else {
+        ((0usize), false, (lo as usize) + 1)
+    }
+}
+
+/// Ensure the numbers are non-decreasing (ascending, duplicates allowed).
+fn ensure_ascending(arr: &[f64]) -> Result<(), String> {
+    if arr.len() <= 1 {
+        return Ok(());
+    }
+    let mut last = arr[0];
+    for (i, &v) in arr.iter().enumerate().skip(1) {
+        if v < last {
+            return Err(format!(
+                "input is not in ascending order at position {}: {} < {}",
+                i + 1,
+                v,
+                last
+            ));
+        }
+        last = v;
+    }
+    Ok(())
+}
+
+// -----------------------------
+// I/O helpers
+// -----------------------------
+
+fn read_numbers<R: BufRead>(reader: R) -> Result<Vec<f64>, String> {
+    let mut out = Vec::with_capacity(1024);
+    for (lineno, line_res) in reader.lines().enumerate() {
+        let line = line_res.map_err(|e| format!("I/O error at line {}: {}", lineno + 1, e))?;
+        let s = line.trim();
+        if s.is_empty() {
+            continue;
+        }
+        match s.parse::<f64>() {
+            Ok(v) => out.push(v),
+            Err(_) => eprintln!("WARN: skipping non-numeric line {}: {:?}", lineno + 1, s),
+        }
+    }
+    Ok(out)
+}
+
+fn read_numbers_from_path<P: AsRef<Path>>(p: P) -> Result<Vec<f64>, String> {
+    let file = File::open(p.as_ref())
+        .map_err(|e| format!("failed to open {:?}: {}", p.as_ref(), e))?;
+    let reader = BufReader::new(file);
+    read_numbers(reader)
+}
+
+fn usage(prog: &str) {
+    eprintln!("Usage:");
+    eprintln!("  {prog} <target_number> [path/to/file]");
+    eprintln!("  {prog} <target_number>   # read numbers from STDIN (one per line)\n");
+    eprintln!("Example:");
+    eprintln!("  printf \"1\\n3\\n4\\n7\\n9\\n11\\n15\\n\" | {prog} 11");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let prog = args.get(0).map(String::as_str).unwrap_or("bsearch");
+
+    if args.len() < 2 {
+        eprintln!("ERROR: missing <target_number>");
+        usage(prog);
+        process::exit(2);
+    }
+
+    let target: f64 = match args[1].parse() {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("ERROR: target_number must be numeric, got {:?}", args[1]);
+            usage(prog);
+            process::exit(2);
+        }
+    };
+
+    let numbers: Vec<f64> = if args.len() >= 3 {
+        match read_numbers_from_path(&args[2]) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("ERROR: {}", e);
+                process::exit(1);
+            }
+        }
+    } else {
+        let stdin = io::stdin();
+        let lock = stdin.lock();
+        match read_numbers(lock) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("ERROR: {}", e);
+                process::exit(1);
+            }
+        }
+    };
+
+    if numbers.is_empty() {
+        eprintln!("ERROR: no numeric input provided");
+        process::exit(1);
+    }
+
+    if let Err(e) = ensure_ascending(&numbers) {
+        eprintln!("ERROR: {}", e);
+        process::exit(1);
+    }
+
+    let (idx, found, ins) = binary_search_first(&numbers, target);
+    if found {
+        println!("FOUND {} at index {} (1-based)", target, idx);
+    } else {
+        let left = if ins >= 2 {
+            format!("{}", numbers[ins - 2])
+        } else {
+            String::from("-inf")
+        };
+        let right = if ins - 1 < numbers.len() {
+            format!("{}", numbers[ins - 1])
+        } else {
+            String::from("+inf")
+        };
+        println!(
+            "NOT FOUND {}. Insertion index {} (1-based), between {} and {}",
+            target, ins, left, right
+        );
+    }
+}

--- a/dev_src/019_binary_search_Scheme.scm
+++ b/dev_src/019_binary_search_Scheme.scm
@@ -1,0 +1,141 @@
+;; binsearch.scm — Binary search (first occurrence) on a sorted ascending list.
+;; Portable Scheme (tested on Guile/Chicken). Run examples:
+;;   guile binsearch.scm -- 11 data.txt
+;;   echo "1\n3\n4\n7\n9\n11\n15\n" | guile binsearch.scm -- 11
+;;
+;; Behavior:
+;;   • O(log N) binary search (lower-bound): returns first index of TARGET if present.
+;;   • Reads newline-separated integers from a file or STDIN.
+;;   • Validates ascending order; warns on non-integer lines.
+
+;; ---------- tiny utils ----------
+(define (eprintln . xs)
+  (let ((out (current-error-port)))
+    (for-each (lambda (x) (display x out)) xs)
+    (newline out)))
+
+(define (string-trim s)
+  (let* ((len (string-length s))
+         (start (let loop ((i 0))
+                  (if (and (< i len)
+                           (or (char=? (string-ref s i) #\space)
+                               (char=? (string-ref s i) #\tab)
+                               (char=? (string-ref s i) #\newline)
+                               (char=? (string-ref s i) #\return)))
+                      (loop (+ i 1))
+                      i)))
+         (end (let loop ((i (- len 1)))
+                (if (and (>= i 0)
+                         (or (char=? (string-ref s i) #\space)
+                             (char=? (string-ref s i) #\tab)
+                             (char=? (string-ref s i) #\newline)
+                             (char=? (string-ref s i) #\return)))
+                    (loop (- i 1))
+                    i))))
+    (if (> end start)
+        (substring s start (+ end 1))
+        "")))
+
+(define (parse-int-or-false s)
+  (let* ((t (string-trim (or s ""))))
+    (if (zero? (string-length t))
+        #f
+        (let ((n (string->number t)))
+          (if (and n (integer? n)) (inexact->exact n) #f)))))
+
+;; ---------- IO ----------
+(define (read-numbers-from-port port)
+  (let loop ((line (read-line port 'concat))
+             (i 1)
+             (acc '()))
+    (if (eof-object? line)
+        (reverse acc)
+        (let ((v (parse-int-or-false line)))
+          (cond
+            ((and (not v)
+                  (positive? (string-length (string-trim line))))
+             (eprintln "WARN: skipping non-integer line " i ": " line)
+             (loop (read-line port 'concat) (+ i 1) acc))
+            (v (loop (read-line port 'concat) (+ i 1) (cons v acc)))
+            (else (loop (read-line port 'concat) (+ i 1) acc)))))))
+
+(define (read-numbers path)
+  (if path
+      (let ((p (open-input-file path)))
+        (let ((xs (read-numbers-from-port p)))
+          (close-input-port p)
+          xs))
+      (read-numbers-from-port (current-input-port))))
+
+;; ---------- checks & search ----------
+(define (ensure-ascending vec)
+  (let ((n (vector-length vec)))
+    (let loop ((i 0))
+      (when (< i (- n 1))
+        (when (< (vector-ref vec (+ i 1)) (vector-ref vec i))
+          (eprintln "ERROR: input not in ascending order at position "
+                    (+ i 2) ": "
+                    (vector-ref vec (+ i 1)) " < " (vector-ref vec i))
+          (exit 3))
+        (loop (+ i 1))))))
+
+;; lower-bound: first index i with vec[i] >= target; returns n if all < target
+(define (lower-bound vec target)
+  (let ((n (vector-length vec)))
+    (let loop ((lo 0) (hi n))
+      (if (< lo hi)
+          (let* ((mid (quotient (+ lo hi) 2))
+                 (vm (vector-ref vec mid)))
+            (if (< vm target)
+                (loop (+ mid 1) hi)
+                (loop lo mid)))
+          lo))))
+
+(define (report vec target)
+  (let* ((n (vector-length vec))
+         (ins (lower-bound vec target)))
+    (if (and (< ins n) (= (vector-ref vec ins) target))
+        (begin
+          (display "FOUND ") (display target)
+          (display " at index ") (display (+ ins 1)) ; 1-based
+          (newline))
+        (let ((left  (if (>= ins 1) (number->string (vector-ref vec (- ins 1))) "-inf"))
+              (right (if (< ins n)  (number->string (vector-ref vec ins))        "+inf")))
+          (display "NOT FOUND ") (display target)
+          (display ". Insertion index ") (display (+ ins 1))
+          (display " (1-based), between ") (display left)
+          (display " and ") (display right)
+          (newline)))))
+
+;; ---------- entrypoint ----------
+(define (usage)
+  (eprintln "Usage: scheme -q binsearch.scm -- <target-int> [path/to/file]")
+  (eprintln "       echo \"1\\n3\\n...\" | scheme -q binsearch.scm -- 11"))
+
+(define (main args)
+  ;; args after '--': (<target> [path])
+  (if (null? args)
+      (begin (usage) (exit 1))
+      (let* ((target-str (car args))
+             (path (and (pair? (cdr args)) (cadr args)))
+             (target (parse-int-or-false target-str)))
+        (if (not target)
+            (begin (eprintln "ERROR: target must be an integer, got '" target-str "'")
+                   (exit 1))
+            (let* ((nums (read-numbers path)))
+              (when (null? nums)
+                (eprintln "ERROR: no numeric input provided.") (exit 2))
+              (let ((vec (list->vector nums)))
+                (ensure-ascending vec)
+                (report vec target)))))))
+
+;; Many Schemes expose the full argv vector; we look for the conventional “--”.
+(let* ((argv (command-line))                         ; e.g., ("guile" "binsearch.scm" "--" "11" "data.txt")
+       (after-dashdash
+        (let loop ((lst argv))
+          (cond
+            ((null? lst) '())
+            ((string=? (car lst) "--") (cdr lst))
+            (else (loop (cdr lst)))))))
+  (main after-dashdash))
+

--- a/dev_src/030_quicksort_R.R
+++ b/dev_src/030_quicksort_R.R
@@ -1,0 +1,131 @@
+#!/usr/bin/env Rscript
+# In-place quicksort on an array (R version).
+# - Reads numbers (ints or floats) one-per-line from a file path (arg1) or stdin.
+# - Ignores blank lines and lines starting with '#'.
+# - Sorts using iterative quicksort with Hoare partition + median-of-three pivot.
+# - Small ranges use insertion sort (faster in practice).
+# - Prints sorted values one per line (integers printed without ".0").
+#
+# Usage:
+#   Rscript quicksort_inplace.R numbers.txt
+#   cat numbers.txt | Rscript quicksort_inplace.R
+
+read_numbers <- function(con) {
+  lines <- readLines(con, warn = FALSE)
+  lines <- trimws(lines)
+  lines <- lines[nzchar(lines) & !startsWith(lines, "#")]
+  if (length(lines) == 0L) return(numeric(0))
+
+  # Parse as numeric; fail on non-finite or non-numeric
+  suppressWarnings(nums <- as.numeric(lines))
+  bad <- which(!is.finite(nums))
+  if (length(bad)) {
+    stop(sprintf("Invalid numeric line at %d: %s",
+                 bad[1], lines[bad[1]]), call. = FALSE)
+  }
+  nums
+}
+
+# Pretty print: integers without trailing .0
+print_numbers <- function(x) {
+  is_int <- abs(x - round(x)) < .Machine$double.eps * 4
+  out <- ifelse(is_int, as.character(round(x)), format(x, scientific = FALSE, trim = TRUE))
+  cat(paste0(out, collapse = "\n"), "\n", sep = "")
+}
+
+# --------- Sorting primitives (1-based indexing) ---------
+
+median_of_three <- function(a, i, j, k) {
+  ai <- a[i]; aj <- a[j]; ak <- a[k]
+  if (ai < aj) {
+    if (aj < ak) j else if (ai < ak) i else k
+  } else {
+    if (ai < ak) i else if (aj < ak) j else k
+  }
+}
+
+insertion_sort <- function(a, lo, hi) {
+  if (lo >= hi) return(a)
+  for (i in (lo + 1L):hi) {
+    key <- a[i]
+    j <- i - 1L
+    while (j >= lo && a[j] > key) {
+      a[j + 1L] <- a[j]
+      j <- j - 1L
+    }
+    a[j + 1L] <- key
+  }
+  a
+}
+
+# Hoare partition: returns p so that [lo..p] <= pivot and [p+1..hi] >= pivot
+hoare_partition <- function(a, lo, hi) {
+  mid  <- lo + ((hi - lo) %/% 2L)
+  pidx <- median_of_three(a, lo, mid, hi)
+  pivot <- a[pidx]
+  i <- lo - 1L
+  j <- hi + 1L
+  repeat {
+    repeat { i <- i + 1L; if (a[i] >= pivot) break }
+    repeat { j <- j - 1L; if (a[j] <= pivot) break }
+    if (i >= j) return(list(a = a, p = j))
+    tmp <- a[i]; a[i] <- a[j]; a[j] <- tmp
+  }
+}
+
+# Iterative quicksort with small-range cutoff
+quicksort_inplace <- function(a) {
+  n <- length(a)
+  if (n < 2L) return(a)
+
+  SMALL <- 32L
+  stack_lo <- integer(0); stack_hi <- integer(0)
+  push <- function(lo, hi) { 
+    stack_lo <<- c(stack_lo, lo); stack_hi <<- c(stack_hi, hi)
+  }
+  pop <- function() {
+    lo <- stack_lo[length(stack_lo)]
+    hi <- stack_hi[length(stack_hi)]
+    stack_lo <<- stack_lo[-length(stack_lo)]
+    stack_hi <<- stack_hi[-length(stack_hi)]
+    c(lo, hi)
+  }
+
+  push(1L, n)
+
+  while (length(stack_lo)) {
+    rng <- pop(); lo <- rng[1]; hi <- rng[2]
+    if (hi - lo + 1L <= SMALL) {
+      a <- insertion_sort(a, lo, hi)
+      next
+    }
+    part <- hoare_partition(a, lo, hi)
+    a <- part$a; p <- part$p
+    left_sz  <- p - lo + 1L
+    right_sz <- hi - (p + 1L) + 1L
+
+    # Process smaller side first (reduces stack depth)
+    if (left_sz < right_sz) {
+      if (p + 1L < hi) push(p + 1L, hi)
+      if (lo < p)      push(lo, p)
+    } else {
+      if (lo < p)      push(lo, p)
+      if (p + 1L < hi) push(p + 1L, hi)
+    }
+  }
+  a
+}
+
+# --------- Main ---------
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) >= 1L) {
+  con <- file(args[1], open = "r")
+  on.exit(close(con), add = TRUE)
+  nums <- read_numbers(con)
+} else {
+  nums <- read_numbers("stdin")
+}
+
+sorted <- quicksort_inplace(nums)
+print_numbers(sorted)
+


### PR DESCRIPTION
Address silent failure in ETL step. Rewired logging hooks to capture late-stage errors. Sanity tested with anonymized inputs